### PR TITLE
account for a lowercase content-type header

### DIFF
--- a/src/Barstool.php
+++ b/src/Barstool.php
@@ -256,7 +256,9 @@ class Barstool
 
         $body = $response->body();
 
-        if (Str::startsWith(mb_strtolower((string) $response->headers()->get('Content-Type')), self::supportedContentTypes())) {
+        $contentTypeHeaderKey = $response->headers()->get('Content-Type') ? 'Content-Type' : 'content-type';
+
+        if (Str::startsWith(mb_strtolower((string) $response->headers()->get($contentTypeHeaderKey)), self::supportedContentTypes())) {
             return self::checkContentSize($body) ? $body : '<Unsupported Barstool Response Content>';
         }
 


### PR DESCRIPTION
Hey 👋 

Firstly, really cool package. I can see myself getting a lot of use out of this on a couple of our systems at work which are super heavy consumers of the Stripe API. 

I did spot one issue in that the response body was always getting set to _Unsupported Barstool Response Content_.

After some digging around, I realised that the code was looking for a _Content-Type_ header, but in my case, and cases I've seen from other APIs, headers aren't always that casing and can sometimes be returned in lowercase:

![Screenshot 2025-02-25 at 00 26 15](https://github.com/user-attachments/assets/1a0bcc8e-69e1-41b7-8960-a6172544ce74)

I've adjusted the code so that if `Content-Type` is null, then it uses `content-type` instead. This now allows me to see the proper response body!

Happy to make any changes that are needed! Keep up great work!

🤠 