### PR TITLE
Exclude authorization header by default

### DIFF
--- a/config/barstool.php
+++ b/config/barstool.php
@@ -60,6 +60,7 @@ return [
      * If all headers are ignored or an entire connector/request is ignored, only the X-Barstool-UUID will be logged.
      */
     'excluded_request_headers' => [
+        'Authorization',
         // '*', // All headers
         // 'token' // Exclude `token` header on all requests
         // SensitiveRequest::class // Exclude ALL headers for this request


### PR DESCRIPTION
This PR excludes the Authorization header by default as it can often contain keys/secrets that a user might not know are getting logged. If they do want the header value to show in the logs, then they can comment it out in the config generated in their own application 😄 