### PR TITLE
Feature | Support application/soap+xml content type

### DIFF
--- a/src/Barstool.php
+++ b/src/Barstool.php
@@ -197,6 +197,7 @@ class Barstool
         return [
             'application/json',
             'application/xml',
+            'application/soap+xml',
             'text/xml',
             'text/html',
             'text/plain',


### PR DESCRIPTION
This PR adds another supported response content type for XML `application/soap+xml` which is pretty much the same as XML from a content perspective.